### PR TITLE
Fix RS07 USB detection in gmenunx

### DIFF
--- a/board/retrofw/package/gmenunx/rs07-fix-usb.patch
+++ b/board/retrofw/package/gmenunx/rs07-fix-usb.patch
@@ -1,0 +1,23 @@
+diff --git a/src/platform/retrofw.h b/src/platform/retrofw.h
+index 514a4d5..7d54fbc 100644
+--- a/src/platform/retrofw.h
++++ b/src/platform/retrofw.h
+@@ -206,6 +206,18 @@
+ 
+ 	uint8_t getUDC() {
+ 		// if (memdev > 0 && ((mem[PDPIN] >> 7 & 1) || (mem[PEPIN] >> 13 & 1))) return UDC_CONNECT;
++		if (fwtype == FW_RETROARCADE) {
++			if (FILE *f = fopen("/proc/jz/udc", "r")) {
++				char buf[7];
++				fread(buf, sizeof(char), 7, f);
++				fclose(f);
++				if (!strncmp(buf, "REMOVE", 6)) {
++					return UDC_REMOVE;
++				} else if (!strncmp(buf, "CONNECT", 7)) {
++					return UDC_CONNECT;
++				}
++			}
++		}
+ 		if (memdev > 0 && (mem[PDPIN] >> 7 & 1)) return UDC_CONNECT;
+ 		return UDC_REMOVE;
+ 	}


### PR DESCRIPTION
Avoid the USB popup dialog in RS07. This fix check the USB status reading `/proc/jz/udc` for RETROARCADE firmware instead of using directly GPIO.